### PR TITLE
Read starter-content from fs instead of network

### DIFF
--- a/inc/client-setup.php
+++ b/inc/client-setup.php
@@ -40,25 +40,25 @@ if (!function_exists('c9_client_setup')) {
 				'posts'	=> array(
 					'home'			=> array(
 						'comment_status'	=> 'closed',
-						'post_content'		=>  $wp_filesystem->get_contents(get_template_directory_uri() . '/client/content/home.html')
+						'post_content'		=>  $wp_filesystem->get_contents(get_template_directory() . '/client/content/home.html')
 					),
 					'about'			=> array(
 						'comment_status'	=> 'closed',
 						'post_type'			=> 'page',
 						'post_title'		=> __('About', 'c9-starter'),
-						'post_content'		=>  $wp_filesystem->get_contents(get_template_directory_uri() . '/client/content/about.html')
+						'post_content'		=>  $wp_filesystem->get_contents(get_template_directory() . '/client/content/about.html')
 					),
 					'setup'		=> array(
 						'comment_status'	=> 'closed',
 						'post_type'			=> 'page',
 						'post_title'		=> __('Setup', 'c9-starter'),
-						'post_content'		=>  $wp_filesystem->get_contents(get_template_directory_uri() . '/client/content/setup.html')
+						'post_content'		=>  $wp_filesystem->get_contents(get_template_directory() . '/client/content/setup.html')
 					),
 					'styleguide'		=> array(
 						'comment_status'	=> 'closed',
 						'post_type'			=> 'page',
 						'post_title'		=> __('Style Guide', 'c9-starter'),
-						'post_content'		=>  $wp_filesystem->get_contents(get_template_directory_uri() . '/client/content/styleguide.html')
+						'post_content'		=>  $wp_filesystem->get_contents(get_template_directory() . '/client/content/styleguide.html')
 					),
 					'blog'			=> array(
 						'post_content'			=> __('This page will show all of the blog posts once you have populated your database with blog items.', 'c9-starter')


### PR DESCRIPTION
`get_template_directory_uri()` returns a network location (which `get_contents` can still request) while `get_template_directory()` returns an file system path, which is what you want here. I noticed the starter-content wasn't working when my dev environment couldn't access it's own domain.